### PR TITLE
daemon: enrich host-project flow with milestones/start-building guidance

### DIFF
--- a/daemon/src/workspace.rs
+++ b/daemon/src/workspace.rs
@@ -341,7 +341,71 @@ impl WorkspaceManager {
         tokio::fs::write(plugin_file, plugin_content).await?;
 
         let host_project_file = commands_dir.join("host-project.md");
-        let host_project_content = "---\ndescription: host current project and provide a URL reachable from my PC\nsubtask: false\n---\n\nHost this project for preview.\n\nContext:\n- opencode is running on a remote Linux server via ttyd.\n- The final preview URL must be reachable from my PC browser, not only from the server itself.\n- Use any available model in this environment (do not depend on one specific model).\n\nRequired flow (do exactly):\n\n1) Find PROJECT_DIR (any stack, not only JS)\n- If current dir has one of: package.json, pyproject.toml, requirements.txt, go.mod, Cargo.toml, Gemfile, composer.json, index.html -> use current dir.\n- Otherwise search child dirs up to depth 3 for those files and pick the nearest match.\n- Print PROJECT_DIR before running anything.\n\n2) Pick port and bind address\n- Use port 3000 first, if busy use 3001.\n- Start server on 0.0.0.0 when possible so it can be reached externally.\n\n3) Install deps + start command by stack\n- Node/JS/TS (package.json): detect package manager from lockfile, install, then run script in order dev -> start -> preview.\n- Python (pyproject.toml/requirements.txt): install deps (pip/poetry/uv) and run framework dev server on chosen port.\n- Go (go.mod): go run/build and serve on chosen port if app supports PORT.\n- Rust (Cargo.toml): cargo run with chosen port env if supported.\n- Static site (index.html only): python3 -m http.server <PORT> --bind 0.0.0.0.\n\n4) Error recovery\n- If output contains dependency errors such as 'Cannot find module', 'Module not found', 'ERR_MODULE_NOT_FOUND', missing package/import, or command not found:\n  a) stop process\n  b) run dependency install/fix for that stack\n  c) retry once\n\n5) Verify local service\n- Wait until curl http://127.0.0.1:<PORT> succeeds (HTTP 200-399) or timeout.\n\n6) Make it reachable from my PC\n- If cloudflared exists, run a quick tunnel to http://127.0.0.1:<PORT> and print the public https://*.trycloudflare.com URL.\n- If cloudflared is unavailable, print exact command to install it and also print fallback URL using server public IP/domain and chosen port.\n\n7) Final output\n- Print: PROJECT_DIR, detected stack, install command, run command, local URL, and public URL for PC access.\n";
+        let host_project_content = r#"---
+description: host current project and provide a URL reachable from my PC
+subtask: false
+---
+
+Host this project for preview.
+
+Context:
+- opencode is running on a remote Linux server via ttyd.
+- The final preview URL must be reachable from my PC browser, not only from the server itself.
+- Use any available model in this environment (do not depend on one specific model).
+
+Milestone-first workflow:
+- When the user includes keyword `milestones`, first create a thoughtful implementation plan with milestones and linked issues/tasks.
+- Milestones and issues must map directly to the user request and include explicit technology choices (framework, runtime, package manager, deployment approach).
+- Keep each issue scoped, testable, and ordered by dependency.
+
+Build execution workflow:
+- When the user includes keyword `start-building`, execute the milestone issues in order and start implementation immediately.
+- Track progress issue-by-issue, and do not stop until all milestone issues are completed.
+- As each issue and milestone completes, update project documentation (README/changelog or relevant docs) with what changed and why.
+- When a milestone completes for a web app, provide the currently hosted preview URL. If missing, run `/host-project` to produce one and report it.
+- If model/token quota is exhausted, preserve progress context and continue from the first incomplete issue after quota refresh.
+
+Required flow (do exactly):
+
+1) Build milestones/issues from request
+- Parse the user request into 3-8 milestone buckets.
+- For each milestone, define concrete issues with acceptance criteria and tech decisions.
+- Announce the milestone plan before writing code.
+
+2) Find PROJECT_DIR (any stack, not only JS)
+- If current dir has one of: package.json, pyproject.toml, requirements.txt, go.mod, Cargo.toml, Gemfile, composer.json, index.html -> use current dir.
+- Otherwise search child dirs up to depth 3 for those files and pick the nearest match.
+- Print PROJECT_DIR before running anything.
+
+3) Pick port and bind address
+- Use port 3000 first, if busy use 3001.
+- Start server on 0.0.0.0 when possible so it can be reached externally.
+
+4) Install deps + start command by stack
+- Node/JS/TS (package.json): detect package manager from lockfile, install, then run script in order dev -> start -> preview.
+- Python (pyproject.toml/requirements.txt): install deps (pip/poetry/uv) and run framework dev server on chosen port.
+- Go (go.mod): go run/build and serve on chosen port if app supports PORT.
+- Rust (Cargo.toml): cargo run with chosen port env if supported.
+- Static site (index.html only): python3 -m http.server <PORT> --bind 0.0.0.0.
+
+5) Error recovery
+- If output contains dependency errors such as 'Cannot find module', 'Module not found', 'ERR_MODULE_NOT_FOUND', missing package/import, or command not found:
+  a) stop process
+  b) run dependency install/fix for that stack
+  c) retry once
+
+6) Verify local service
+- Wait until curl http://127.0.0.1:<PORT> succeeds (HTTP 200-399) or timeout.
+
+7) Make it reachable from my PC
+- If cloudflared exists, run a quick tunnel to http://127.0.0.1:<PORT> and print the public https://*.trycloudflare.com URL.
+- If cloudflared is unavailable, use another available tunnel/proxy approach and print the reachable URL.
+- As a fallback, print the server public IP/domain with port and clear firewall/security-group steps.
+
+8) Return concise result
+- Always return: stack detected, PROJECT_DIR, local URL, public URL, command used to run app, and current status.
+- If unresolved, return exact failing command + last 40 lines of stderr and the next fix you will attempt.
+"#;
         tokio::fs::write(host_project_file, host_project_content).await?;
 
         Ok(())


### PR DESCRIPTION
## Summary
- Extend the generated `.opencode/command/host-project.md` template to recognize and act on `milestones` and `start-building` workflow expectations.
- Add explicit milestone/issue planning guidance, technology decision requirements, documentation update expectations, and hosted URL reporting on milestone completion.
- Keep existing hosting behavior while improving fallback guidance and final response requirements for reliable remote preview sharing.

## Verification
- `cargo fmt --manifest-path daemon/Cargo.toml`
- `cargo check --manifest-path daemon/Cargo.toml`
- `cargo test --manifest-path daemon/Cargo.toml`