### PR TITLE
dashboard: add VM CPU/RAM/Disk usage percentages

### DIFF
--- a/daemon/src/server.rs
+++ b/daemon/src/server.rs
@@ -116,6 +116,7 @@ impl From<&crate::state::Workspace> for WorkspaceResponse {
 struct VmInfoResponse {
     hostname: String,
     cpu_cores: u32,
+    cpu_usage_percent: Option<f64>,
     memory_total_mb: u64,
     memory_used_mb: u64,
     disk_total_gb: u64,
@@ -515,6 +516,8 @@ async fn vm_info() -> Result<Json<VmInfoResponse>, AppError> {
         .and_then(|value| value.parse::<u32>().ok())
         .unwrap_or(0);
 
+    let cpu_usage_percent = sample_cpu_usage_percent().await;
+
     let (memory_total_mb, memory_used_mb) = parse_memory_info(
         run_command("free", &["-m"])
             .await
@@ -546,6 +549,7 @@ async fn vm_info() -> Result<Json<VmInfoResponse>, AppError> {
     Ok(Json(VmInfoResponse {
         hostname,
         cpu_cores,
+        cpu_usage_percent,
         memory_total_mb,
         memory_used_mb,
         disk_total_gb,
@@ -667,6 +671,43 @@ fn parse_memory_info(free_output: &str) -> (u64, u64) {
         }
     }
     (0, 0)
+}
+
+fn parse_cpu_times(proc_stat: &str) -> Option<(u64, u64)> {
+    let line = proc_stat.lines().find(|line| line.starts_with("cpu "))?;
+    let mut fields = line.split_whitespace();
+    let _ = fields.next();
+
+    let values: Vec<u64> = fields
+        .filter_map(|value| value.parse::<u64>().ok())
+        .collect();
+    if values.len() < 4 {
+        return None;
+    }
+
+    let idle = values[3].saturating_add(*values.get(4).unwrap_or(&0));
+    let total = values.iter().sum();
+    Some((idle, total))
+}
+
+async fn sample_cpu_usage_percent() -> Option<f64> {
+    let first = tokio::fs::read_to_string("/proc/stat").await.ok()?;
+    let (idle1, total1) = parse_cpu_times(&first)?;
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let second = tokio::fs::read_to_string("/proc/stat").await.ok()?;
+    let (idle2, total2) = parse_cpu_times(&second)?;
+
+    let total_delta = total2.saturating_sub(total1);
+    if total_delta == 0 {
+        return None;
+    }
+
+    let idle_delta = idle2.saturating_sub(idle1);
+    let busy_delta = total_delta.saturating_sub(idle_delta);
+    let percent = (busy_delta as f64 / total_delta as f64) * 100.0;
+    Some((percent * 10.0).round() / 10.0)
 }
 
 fn parse_disk_info(df_output: &str) -> (u64, u64) {

--- a/daemon/static/index.html
+++ b/daemon/static/index.html
@@ -444,6 +444,20 @@
       return `<div class="metric"><div class="label">${label}</div><div class="value">${value}</div></div>`;
     }
 
+    function usagePercent(used, total) {
+      if (!Number.isFinite(used) || !Number.isFinite(total) || total <= 0) {
+        return null;
+      }
+      return (used / total) * 100;
+    }
+
+    function formatPercent(value) {
+      if (!Number.isFinite(value)) {
+        return "-";
+      }
+      return `${value.toFixed(1)}%`;
+    }
+
     function setGlobalError(message) {
       topError.textContent = message || "";
     }
@@ -478,13 +492,17 @@
 
     function render() {
       const vm = state.vm;
+      const memoryPercent = vm ? usagePercent(vm.memory_used_mb, vm.memory_total_mb) : null;
+      const diskPercent = vm ? usagePercent(vm.disk_used_gb, vm.disk_total_gb) : null;
+
       vmMetrics.innerHTML = vm
         ? [
             metric("Hostname", vm.hostname || "-"),
             metric("OS", vm.os || "-"),
             metric("CPU Cores", formatNumber(vm.cpu_cores, "")),
-            metric("Memory", `${formatNumber(vm.memory_used_mb, "")} / ${formatNumber(vm.memory_total_mb, "")} MB`),
-            metric("Disk", `${formatNumber(vm.disk_used_gb, "")} / ${formatNumber(vm.disk_total_gb, "")} GB`),
+            metric("CPU Usage", formatPercent(vm.cpu_usage_percent)),
+            metric("RAM Usage", `${formatNumber(vm.memory_used_mb, "")} / ${formatNumber(vm.memory_total_mb, "")} MB (${formatPercent(memoryPercent)})`),
+            metric("Disk Usage", `${formatNumber(vm.disk_used_gb, "")} / ${formatNumber(vm.disk_total_gb, "")} GB (${formatPercent(diskPercent)})`),
             metric("Uptime", formatUptime(vm.uptime_seconds)),
           ].join("")
         : "<div class='label'>Loading VM details...</div>";


### PR DESCRIPTION
## Summary
- Add CPU usage sampling in `/api/vm` so VM details include a live CPU utilization percentage.
- Update dashboard VM cards to show CPU usage and RAM/Disk percentages alongside used/total values.
- Keep existing VM details behavior intact while making host utilization easier to read at a glance.